### PR TITLE
Update build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ env:
 sudo: required
 # Before anything else, get the latest versions of things
 before_script:
-  - julia -e 'using Pkg; pkg"add BinaryBuilder BinaryProvider"'
+  - julia -e 'using Pkg; pkg"add BinaryProvider"; pkg"add BinaryBuilder#master"; Pkg.build()'
 
 script:
-- julia build_tarballs.jl
+  - julia build_tarballs.jl
 
 deploy:
   provider: releases

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -17,12 +17,10 @@ sources = [
 
 # Bash recipe for building across all platforms
 script = raw"""
-cd $WORKSPACE/srcdir
-cd cairo-1.14.12/
-LDFLAGS="-L$prefix/lib" CPPFLAGS="-I$prefix/include" ./configure --prefix=$prefix --host=$target --disable-static --disable-xlib --disable-ft --disable-dependency-tracking
-make -j${ncore}
+cd $WORKSPACE/srcdir/cairo-*/
+LDFLAGS="-L$prefix/lib -L/opt/${target}/${target}/lib" CPPFLAGS="-I$prefix/include" ./configure --prefix=$prefix --host=$target --disable-static --disable-xlib --disable-ft --disable-dependency-tracking
+make -j${nproc}
 make install
-exit
 """
 
 # These are the platforms we will build for by default, unless further
@@ -36,10 +34,10 @@ products(prefix) = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    "https://github.com/bicycle1885/ZlibBuilder/releases/download/v1.0.1/build_Zlib.v1.2.11.jl",
-    "https://github.com/SimonDanisch/LibpngBuilder/releases/download/v1.6.31/build_libpng.v1.0.0.jl",
-    "https://github.com/staticfloat/PixmanBuilder/releases/download/v0.34.0-1/build_Pixman.v0.34.0.jl",
-    "https://github.com/JuliaGraphics/FreeTypeBuilder/releases/download/v2.9.1-2/build_FreeType2.v2.9.1.jl"
+    "https://github.com/bicycle1885/ZlibBuilder/releases/download/v1.0.4/build_Zlib.v1.2.11.jl",
+    "https://github.com/JuliaIO/LibpngBuilder/releases/download/v1.0.3/build_libpng.v1.6.37.jl",
+    "https://github.com/JuliaPackaging/Yggdrasil/releases/download/Pixman-v0.36.0-0/build_Pixman.v0.36.0.jl",
+    "https://github.com/JuliaGraphics/FreeTypeBuilder/releases/download/v2.9.1-4/build_FreeType2.v2.10.0.jl"
 ]
 
 


### PR DESCRIPTION
Nothing special, just update the dependencies to the latest available versions and fix the name of the environment variables holding the number of available threads (probably it changed since last year).

Fix #3.

PS: I started hacking pango... :eyes: 